### PR TITLE
Http long polling transport options cleanup

### DIFF
--- a/Genesys.Bayeux.Client.Tests/BayeuxClientTest.cs
+++ b/Genesys.Bayeux.Client.Tests/BayeuxClientTest.cs
@@ -108,7 +108,7 @@ namespace Genesys.Bayeux.Client.Tests
                 ;
 
             var bayeuxClient = new BayeuxClient(
-                new HttpLongPollingTransportOptions() { HttpClient = new HttpClient(mock.Object), Uri = Url }, 
+                new HttpLongPollingTransportOptions(new HttpClient(mock.Object), Url), 
                 reconnectDelays: new[] { TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2) });
 
             using (bayeuxClient)
@@ -133,7 +133,7 @@ namespace Genesys.Bayeux.Client.Tests
                 ;
 
             var bayeuxClient = new BayeuxClient(
-                new HttpLongPollingTransportOptions() { HttpClient = new HttpClient(mock.Object), Uri = Url },
+                new HttpLongPollingTransportOptions(new HttpClient(mock.Object), Url),
                 reconnectDelays: new[] { TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2) });
 
             using (bayeuxClient)
@@ -170,7 +170,7 @@ namespace Genesys.Bayeux.Client.Tests
                         .ContinueWith(t => BuildBayeuxResponse(successfulConnectResponse)));
 
             var bayeuxClient = new BayeuxClient(
-                new HttpLongPollingTransportOptions() { HttpClient = new HttpClient(mock.Object), Uri = Url },
+                new HttpLongPollingTransportOptions(new HttpClient(mock.Object), Url),
                 reconnectDelays: new[] { TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2) });
 
             using (bayeuxClient)
@@ -256,7 +256,7 @@ namespace Genesys.Bayeux.Client.Tests
         public async Task Subscribe_throws_exception_when_not_connected()
         {
             var httpPoster = new Mock<IHttpPost>();
-            var bayeuxClient = new BayeuxClient(new HttpLongPollingTransportOptions() { HttpPost = httpPoster.Object, Uri = "none" });
+            var bayeuxClient = new BayeuxClient(new HttpLongPollingTransportOptions(httpPoster.Object, "none"));
             await bayeuxClient.Subscribe("dummy").ConfigureAwait(false);
         }
 
@@ -265,7 +265,7 @@ namespace Genesys.Bayeux.Client.Tests
         public async Task Unsubscribe_throws_exception_when_not_connected()
         {
             var httpPoster = new Mock<IHttpPost>();
-            var bayeuxClient = new BayeuxClient(new HttpLongPollingTransportOptions() { HttpPost = httpPoster.Object, Uri = "none" });
+            var bayeuxClient = new BayeuxClient(new HttpLongPollingTransportOptions(httpPoster.Object, "none"));
             await bayeuxClient.Unsubscribe("dummy").ConfigureAwait(false);
         }
 
@@ -273,7 +273,7 @@ namespace Genesys.Bayeux.Client.Tests
         public void AddSubscriptions_succeeds_when_not_connected()
         {
             var httpPoster = new Mock<IHttpPost>();
-            var bayeuxClient = new BayeuxClient(new HttpLongPollingTransportOptions() { HttpPost = httpPoster.Object, Uri = "none" });
+            var bayeuxClient = new BayeuxClient(new HttpLongPollingTransportOptions(httpPoster.Object, "none"));
             bayeuxClient.AddSubscriptions("dummy");
         }
 
@@ -281,17 +281,13 @@ namespace Genesys.Bayeux.Client.Tests
         public void RemoveSubscriptions_succeeds_when_not_connected()
         {
             var httpPoster = new Mock<IHttpPost>();
-            var bayeuxClient = new BayeuxClient(new HttpLongPollingTransportOptions() { HttpPost = httpPoster.Object, Uri = "none" });
+            var bayeuxClient = new BayeuxClient(new HttpLongPollingTransportOptions(httpPoster.Object, "none"));
             bayeuxClient.RemoveSubscriptions("dummy");
         }
 
         BayeuxClient CreateHttpBayeuxClient(HttpClient httpClient = null, string uri = Url)
         {
-            return new BayeuxClient(new HttpLongPollingTransportOptions()
-            {
-                HttpClient = httpClient,
-                Uri = uri,
-            });
+            return new BayeuxClient(new HttpLongPollingTransportOptions(httpClient, uri));
         }
     }
 }

--- a/Genesys.Bayeux.Client.Tests/BayeuxClientTest.cs
+++ b/Genesys.Bayeux.Client.Tests/BayeuxClientTest.cs
@@ -41,7 +41,7 @@ namespace Genesys.Bayeux.Client.Tests
 
             using (var bayeuxClient = CreateHttpBayeuxClient(httpClient))
             {
-                await bayeuxClient.Start();
+                await bayeuxClient.Start().ConfigureAwait(false);
             }
         }
 
@@ -78,7 +78,7 @@ namespace Genesys.Bayeux.Client.Tests
 
             using (var bayeuxClient = CreateHttpBayeuxClient(httpClient))
             {
-                await bayeuxClient.Start();
+                await bayeuxClient.Start().ConfigureAwait(false);
             }
 
             mock.Protected().As<IHttpMessageHandlerProtected>()
@@ -113,8 +113,8 @@ namespace Genesys.Bayeux.Client.Tests
 
             using (bayeuxClient)
             {
-                await bayeuxClient.Start();
-                await Task.Delay(TimeSpan.FromSeconds(20));
+                await bayeuxClient.Start().ConfigureAwait(false);
+                await Task.Delay(TimeSpan.FromSeconds(20)).ConfigureAwait(false);
             }
         }
 
@@ -139,7 +139,7 @@ namespace Genesys.Bayeux.Client.Tests
             using (bayeuxClient)
             {
                 bayeuxClient.StartInBackground();
-                await Task.Delay(TimeSpan.FromSeconds(20));
+                await Task.Delay(TimeSpan.FromSeconds(20)).ConfigureAwait(false);
             }
         }
 
@@ -176,8 +176,8 @@ namespace Genesys.Bayeux.Client.Tests
             using (bayeuxClient)
             {
                 bayeuxClient.AddSubscriptions("/mychannel");
-                await bayeuxClient.Start();
-                await Task.Delay(TimeSpan.FromSeconds(2));
+                await bayeuxClient.Start().ConfigureAwait(false);
+                await Task.Delay(TimeSpan.FromSeconds(2)).ConfigureAwait(false);
             }
 
             Assert.AreEqual(1, subscriptionCount);
@@ -257,7 +257,7 @@ namespace Genesys.Bayeux.Client.Tests
         {
             var httpPoster = new Mock<IHttpPost>();
             var bayeuxClient = new BayeuxClient(new HttpLongPollingTransportOptions() { HttpPost = httpPoster.Object, Uri = "none" });
-            await bayeuxClient.Subscribe("dummy");
+            await bayeuxClient.Subscribe("dummy").ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -266,7 +266,7 @@ namespace Genesys.Bayeux.Client.Tests
         {
             var httpPoster = new Mock<IHttpPost>();
             var bayeuxClient = new BayeuxClient(new HttpLongPollingTransportOptions() { HttpPost = httpPoster.Object, Uri = "none" });
-            await bayeuxClient.Unsubscribe("dummy");
+            await bayeuxClient.Unsubscribe("dummy").ConfigureAwait(false);
         }
 
         [TestMethod]

--- a/Genesys.Bayeux.Client.Tests/DotNetChecks.cs
+++ b/Genesys.Bayeux.Client.Tests/DotNetChecks.cs
@@ -17,7 +17,7 @@ namespace Genesys.Bayeux.Client.Tests
         {
             var cancel = new CancellationTokenSource();
             cancel.Cancel();
-            await new HttpClient().GetAsync("http://www.google.com", cancel.Token);
+            await new HttpClient().GetAsync("http://www.google.com", cancel.Token).ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -31,7 +31,7 @@ namespace Genesys.Bayeux.Client.Tests
             {
                 Debug.WriteLine($"Inside task: Task.Id = {Task.CurrentId}");
                 Debug.WriteLine($"Inside task: SynchronizationContext.Current = {SynchronizationContext.Current}");
-            });
+            }).ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -67,7 +67,7 @@ namespace Genesys.Bayeux.Client.Tests
         {
             try
             {
-                await Task.Run(() => throw new Exception("Test"));
+                await Task.Run(() => throw new Exception("Test")).ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -78,7 +78,7 @@ namespace Genesys.Bayeux.Client.Tests
 
         async Task ThrowExcAsync()
         {
-            await Task.Run(() => throw new Exception("Test"));
+            await Task.Run(() => throw new Exception("Test")).ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -86,7 +86,7 @@ namespace Genesys.Bayeux.Client.Tests
         {
             try
             {
-                await ThrowExcAsync();
+                await ThrowExcAsync().ConfigureAwait(false);
             }
             catch
             {
@@ -108,14 +108,14 @@ namespace Genesys.Bayeux.Client.Tests
 
             Task completedTask = await Task.WhenAny(
                 Task.Delay(TimeSpan.FromSeconds(60)),
-                Task.Delay(TimeSpan.FromSeconds(30), cancellationSource.Token));
+                Task.Delay(TimeSpan.FromSeconds(30), cancellationSource.Token)).ConfigureAwait(false);
             
             Assert.IsTrue(completedTask.IsCanceled);
         }
 
         async Task PleaseThrow()
         {
-            await Task.FromResult(0);
+            await Task.FromResult(0).ConfigureAwait(false);
             throw new OperationCanceledException();
         }
 
@@ -123,20 +123,20 @@ namespace Genesys.Bayeux.Client.Tests
         [ExpectedException(typeof(OperationCanceledException))]
         public async Task Check_exception_thrown_on_cancel()
         {
-            await PleaseThrow();
+            await PleaseThrow().ConfigureAwait(false);
         }
 
         async Task PleaseThrow2(CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            await Task.Delay(0);
+            await Task.Delay(0).ConfigureAwait(false);
         }
 
         [TestMethod]
         [ExpectedException(typeof(OperationCanceledException))]
         public async Task Check_exception_thrown_on_cancel_with_cancellationToken_as_method_parameter()
         {
-            await PleaseThrow2(new CancellationToken(canceled: true));
+            await PleaseThrow2(new CancellationToken(canceled: true)).ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -146,7 +146,7 @@ namespace Genesys.Bayeux.Client.Tests
             var cancellationToken = new CancellationToken(canceled: true);
             await Task.Run(
                 () => PleaseThrow2(cancellationToken), 
-                cancellationToken);
+                cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/Genesys.Bayeux.Client.Tests/RealLocalTest.cs
+++ b/Genesys.Bayeux.Client.Tests/RealLocalTest.cs
@@ -1,17 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Configuration;
 using System.Diagnostics;
-using System.Net;
 using System.Net.Http;
 using System.Net.WebSockets;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Genesys.Bayeux.Client;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace Genesys.Bayeux.Client.Tests
 {
@@ -24,11 +17,7 @@ namespace Genesys.Bayeux.Client.Tests
             // Begin: README example
             var httpClient = new HttpClient();
             var bayeuxClient = new BayeuxClient(
-                new HttpLongPollingTransportOptions()
-                {
-                    HttpClient = httpClient,
-                    Uri = "http://localhost:8080/bayeux/",
-                });
+                new HttpLongPollingTransportOptions(httpClient, "http://localhost:8080/bayeux/"));
 
             bayeuxClient.EventReceived += (e, args) =>
                 Debug.WriteLine($"Event received on channel {args.Channel} with data\n{args.Data}");

--- a/Genesys.Bayeux.Client.Tests/RealLocalTest.cs
+++ b/Genesys.Bayeux.Client.Tests/RealLocalTest.cs
@@ -38,12 +38,12 @@ namespace Genesys.Bayeux.Client.Tests
 
             bayeuxClient.AddSubscriptions("/**");
 
-            await bayeuxClient.Start();
+            await bayeuxClient.Start().ConfigureAwait(false);
             // End: README example
 
             using (bayeuxClient)
             {
-                await Delay(60);
+                await Delay(60).ConfigureAwait(false);
             }
         }        
 
@@ -66,11 +66,11 @@ namespace Genesys.Bayeux.Client.Tests
 
             bayeuxClient.AddSubscriptions("/**");
 
-            await bayeuxClient.Start();
+            await bayeuxClient.Start().ConfigureAwait(false);
 
             using (bayeuxClient)
             {
-                await Delay(60);
+                await Delay(60).ConfigureAwait(false);
             }
         }
 
@@ -90,17 +90,17 @@ namespace Genesys.Bayeux.Client.Tests
             using (var webSocket = SystemClientWebSocket.CreateClientWebSocket())
             {
                 Debug.WriteLine("Connecting");
-                await webSocket.ConnectAsync(new Uri("ws://localhost:5088/bayeux/"), CancellationToken.None);
-                await Delay(10);
+                await webSocket.ConnectAsync(new Uri("ws://localhost:5088/bayeux/"), CancellationToken.None).ConfigureAwait(false);
+                await Delay(10).ConfigureAwait(false);
                 //Debug.WriteLine("Sending");
                 //await webSocket.SendAsync(new ArraySegment<byte>(Encoding.UTF8.GetBytes("hola")), WebSocketMessageType.Text, endOfMessage: true, cancellationToken: CancellationToken.None);
                 //await Delay(10);
                 Debug.WriteLine("Closing");
-                await webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "", CancellationToken.None);
-                await Delay(5);
+                await webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "", CancellationToken.None).ConfigureAwait(false);
+                await Delay(5).ConfigureAwait(false);
                 Debug.WriteLine("Connecting again");
-                await webSocket.ConnectAsync(new Uri("ws://localhost:5088/bayeux/"), CancellationToken.None);
-                await Delay(5);
+                await webSocket.ConnectAsync(new Uri("ws://localhost:5088/bayeux/"), CancellationToken.None).ConfigureAwait(false);
+                await Delay(5).ConfigureAwait(false);
                 Debug.WriteLine("End");
             }
         }
@@ -108,7 +108,7 @@ namespace Genesys.Bayeux.Client.Tests
         async Task Delay(int seconds)
         {
             Debug.WriteLine($"Waiting {seconds}s...");
-            await Task.Delay(TimeSpan.FromSeconds(seconds));
+            await Task.Delay(TimeSpan.FromSeconds(seconds)).ConfigureAwait(false);
         }
     }
 }

--- a/Genesys.Bayeux.Client/BayeuxClient.cs
+++ b/Genesys.Bayeux.Client/BayeuxClient.cs
@@ -135,7 +135,7 @@ namespace Genesys.Bayeux.Client
 
             var connection = Interlocked.Exchange(ref currentConnection, null);
             if (connection != null)
-                await connection.Disconnect(cancellationToken);
+                await connection.Disconnect(cancellationToken).ConfigureAwait(false);
         }
 
         public void Dispose()
@@ -279,7 +279,7 @@ namespace Genesys.Bayeux.Client
             }
             else
             {
-                await connection.DoSubscription(channelsToSubscribe, channelsToUnsubscribe, cancellationToken);
+                await connection.DoSubscription(channelsToSubscribe, channelsToUnsubscribe, cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -301,7 +301,7 @@ namespace Genesys.Bayeux.Client
         {
             // https://docs.cometd.org/current/reference/#_messages
             // All Bayeux messages SHOULD be encapsulated in a JSON encoded array so that multiple messages may be transported together
-            var responseObj = await transport.Request(requests, cancellationToken);
+            var responseObj = await transport.Request(requests, cancellationToken).ConfigureAwait(false);
 
             var response = responseObj.ToObject<BayeuxResponse>();
 

--- a/Genesys.Bayeux.Client/BayeuxConnection.cs
+++ b/Genesys.Bayeux.Client/BayeuxConnection.cs
@@ -31,7 +31,7 @@ namespace Genesys.Bayeux.Client
                     channel = "/meta/connect",
                     connectionType = "long-polling",
                 },
-                cancellationToken);
+                cancellationToken).ConfigureAwait(false);
 
             context.SetConnectionState(BayeuxClient.ConnectionState.Connected);
 

--- a/Genesys.Bayeux.Client/ConnectLoop.cs
+++ b/Genesys.Bayeux.Client/ConnectLoop.cs
@@ -54,8 +54,8 @@ namespace Genesys.Bayeux.Client
             if (startLatch.AlreadyRun())
                 throw new Exception("Already started.");
 
-            await context.Open(cancellationToken);
-            await Handshake(cancellationToken);
+            await context.Open(cancellationToken).ConfigureAwait(false);
+            await Handshake(cancellationToken).ConfigureAwait(false);
 
             // A way to test the re-handshake with a real server is to put some delay here, between the first handshake response,
             // and the first try to connect. That will cause an "Invalid client id" response, with an advice of reconnect=handshake.
@@ -79,7 +79,7 @@ namespace Genesys.Bayeux.Client
             try
             {
                 while (!pollCancel.IsCancellationRequested)
-                    await Poll();
+                    await Poll().ConfigureAwait(false);
 
                 context.SetConnectionState(ConnectionState.Disconnected);
                 log.Info("Long-polling stopped.");
@@ -111,8 +111,8 @@ namespace Genesys.Bayeux.Client
                 if (startInBackground)
                 {
                     startInBackground = false;
-                    await context.Open(pollCancel.Token);
-                    await Handshake(pollCancel.Token);
+                    await context.Open(pollCancel.Token).ConfigureAwait(false);
+                    await Handshake(pollCancel.Token).ConfigureAwait(false);
                 }
                 else if (transportFailed)
                 {
@@ -122,11 +122,11 @@ namespace Genesys.Bayeux.Client
                     {
                         transportClosed = false;
                         log.Info($"Re-opening transport due to previously failed request.");
-                        await context.Open(pollCancel.Token);
+                        await context.Open(pollCancel.Token).ConfigureAwait(false);
                     }
 
                     log.Info($"Re-handshaking due to previously failed request.");
-                    await Handshake(pollCancel.Token);
+                    await Handshake(pollCancel.Token).ConfigureAwait(false);
                 }
                 else switch (lastAdvice.reconnect)
                     {
@@ -145,8 +145,8 @@ namespace Genesys.Bayeux.Client
 
                         case "handshake":
                             log.Info($"Re-handshaking after {lastAdvice.interval} ms on server request.");
-                            await Task.Delay(lastAdvice.interval);
-                            await Handshake(pollCancel.Token);
+                            await Task.Delay(lastAdvice.interval).ConfigureAwait(false);
+                            await Handshake(pollCancel.Token).ConfigureAwait(false);
                             break;
 
                         case "retry":
@@ -154,8 +154,8 @@ namespace Genesys.Bayeux.Client
                             if (lastAdvice.interval > 0)
                                 log.Info($"Re-connecting after {lastAdvice.interval} ms on server request.");
 
-                            await Task.Delay(lastAdvice.interval);
-                            await Connect(pollCancel.Token);
+                            await Task.Delay(lastAdvice.interval).ConfigureAwait(false);
+                            await Connect(pollCancel.Token).ConfigureAwait(false);
                             break;
                     }
             }
@@ -166,7 +166,7 @@ namespace Genesys.Bayeux.Client
 
                 var reconnectDelay = reconnectDelays.GetNext();
                 log.WarnException($"HTTP request failed. Rehandshaking after {reconnectDelay}", e);
-                await Task.Delay(reconnectDelay);
+                await Task.Delay(reconnectDelay).ConfigureAwait(false);
             }
             catch (BayeuxTransportException e)
             {
@@ -177,7 +177,7 @@ namespace Genesys.Bayeux.Client
 
                 var reconnectDelay = reconnectDelays.GetNext();
                 log.WarnException($"Request transport failed. Retrying after {reconnectDelay}", e);
-                await Task.Delay(reconnectDelay);
+                await Task.Delay(reconnectDelay).ConfigureAwait(false);
             }
             catch (BayeuxRequestException e)
             {
@@ -197,7 +197,7 @@ namespace Genesys.Bayeux.Client
                     version = "1.0",
                     supportedConnectionTypes = new[] { connectionType },
                 },
-                cancellationToken);
+                cancellationToken).ConfigureAwait(false);
 
             currentConnection = new BayeuxConnection((string)response["clientId"], context);
             context.SetConnection(currentConnection);
@@ -207,7 +207,7 @@ namespace Genesys.Bayeux.Client
 
         async Task Connect(CancellationToken cancellationToken)
         {
-            var connectResponse = await currentConnection.Connect(cancellationToken);
+            var connectResponse = await currentConnection.Connect(cancellationToken).ConfigureAwait(false);
             ObtainAdvice(connectResponse);
         }
 

--- a/Genesys.Bayeux.Client/HttpLongPollingTransport.cs
+++ b/Genesys.Bayeux.Client/HttpLongPollingTransport.cs
@@ -62,17 +62,17 @@ namespace Genesys.Bayeux.Client
             var messageStr = JsonConvert.SerializeObject(requests);
             log.Debug(() => $"Posting: {messageStr}");
 
-            var httpResponse = await httpPost.PostAsync(url, messageStr, cancellationToken);
+            var httpResponse = await httpPost.PostAsync(url, messageStr, cancellationToken).ConfigureAwait(false);
 
             if (!httpResponse.IsSuccessStatusCode)
             {
-                var responseStr = await httpResponse.Content.ReadAsStringAsync();
+                var responseStr = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                 log.Debug(() => $"Received: {responseStr}");
             }
 
             httpResponse.EnsureSuccessStatusCode();
 
-            var responseToken = JToken.ReadFrom(new JsonTextReader(new StreamReader(await httpResponse.Content.ReadAsStreamAsync())));
+            var responseToken = JToken.ReadFrom(new JsonTextReader(new StreamReader(await httpResponse.Content.ReadAsStreamAsync().ConfigureAwait(false))));
             log.Debug(() => $"Received: {responseToken.ToString(Formatting.None)}");
             
             IEnumerable<JToken> tokens = responseToken is JArray ?

--- a/Genesys.Bayeux.Client/HttpLongPollingTransportOptions.cs
+++ b/Genesys.Bayeux.Client/HttpLongPollingTransportOptions.cs
@@ -16,13 +16,21 @@ namespace Genesys.Bayeux.Client
         }
         public HttpLongPollingTransportOptions(IHttpPost httpPost, string uri)
         {
-            this.HttpPost = httpPost;
+            if (string.IsNullOrWhiteSpace(uri))
+            {
+                throw new ArgumentNullException(nameof(uri), "Must provide a valid Uri");
+            }
+            this.HttpPost = httpPost ?? throw new ArgumentNullException(nameof(httpPost),"HttpPost cannot be null");
             Uri = uri;
         }
 
         public HttpLongPollingTransportOptions(HttpClient client, string uri)
         {
-            HttpClient = client;
+            if (string.IsNullOrWhiteSpace(uri))
+            {
+                throw new ArgumentNullException(nameof(uri), "Must provide a valid Uri");
+            }
+            HttpClient = client ?? throw new ArgumentNullException(nameof(client), "HttpClient cannot be null");
             Uri = uri;
         }
 

--- a/Genesys.Bayeux.Client/HttpLongPollingTransportOptions.cs
+++ b/Genesys.Bayeux.Client/HttpLongPollingTransportOptions.cs
@@ -9,6 +9,25 @@ namespace Genesys.Bayeux.Client
 {
     public class HttpLongPollingTransportOptions
     {
+        [Obsolete("Please use either the HttpLongPollingTransportOptions(IHttpPost httpPost, string uri) or HttpLongPollingTransportOptions(HttpClient client, string uri) constructors.")]
+        public HttpLongPollingTransportOptions()
+        {
+            
+        }
+        public HttpLongPollingTransportOptions(IHttpPost httpPost, string uri)
+        {
+            this.HttpPost = httpPost;
+            Uri = uri;
+        }
+
+        public HttpLongPollingTransportOptions(HttpClient client, string uri)
+        {
+            HttpClient = client;
+            Uri = uri;
+        }
+
+        private IHttpPost _httpPost;
+        private HttpClient _httpClient;
         /// <summary>
         /// An HTTP POST implementation. It should not do HTTP pipelining (rarely done for POSTs anyway).
         /// See https://docs.cometd.org/current/reference/#_two_connection_operation.
@@ -21,7 +40,10 @@ namespace Genesys.Bayeux.Client
         /// Enables the implementation of retry policies; useful for servers that may occasionally need a session refresh. Retries are general not supported by HttpClient, as (for some versions) SendAsync disposes the content of HttpRequestMessage. This means that a failed SendAsync call can't be retried, as the HttpRequestMessage can't be reused.
         /// </para>
         /// </summary>
-        public IHttpPost HttpPost;
+        public IHttpPost HttpPost {
+            get => _httpPost;
+            set => _httpPost = value;
+        }
 
         /// <summary>
         /// HttpClient to use.
@@ -30,7 +52,11 @@ namespace Genesys.Bayeux.Client
         /// Set this property or HttpPost, but not both.
         /// </para>
         /// </summary>
-        public HttpClient HttpClient;
+        public  HttpClient HttpClient
+        {
+            get => _httpClient;
+            set => _httpClient = value;
+        }
 
         public string Uri { get; set; }
 
@@ -48,8 +74,6 @@ namespace Genesys.Bayeux.Client
             }
             else
             {
-                if (HttpClient != null)
-                    throw new Exception("Set HttpPost or HttpClient, but not both.");
 
                 return new HttpLongPollingTransport(
                     HttpPost,

--- a/Genesys.Bayeux.Client/WebSocketTransport.cs
+++ b/Genesys.Bayeux.Client/WebSocketTransport.cs
@@ -64,7 +64,7 @@ namespace Genesys.Bayeux.Client
             if (receiverLoopCancel != null)
             {
                 receiverLoopCancel.Cancel();
-                await receiverLoopTask;
+                await receiverLoopTask.ConfigureAwait(false);
             }
 
             if (webSocket != null)
@@ -74,7 +74,7 @@ namespace Genesys.Bayeux.Client
 
             try
             {
-                await webSocket.ConnectAsync(uri, cancellationToken);
+                await webSocket.ConnectAsync(uri, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -92,7 +92,7 @@ namespace Genesys.Bayeux.Client
             try
             {
                 while (!cancelToken.IsCancellationRequested)
-                    HandleReceivedMessage(await ReceiveMessage(cancelToken));
+                    HandleReceivedMessage(await ReceiveMessage(cancelToken).ConfigureAwait(false));
 
                 fault = null;
             }
@@ -138,7 +138,7 @@ namespace Genesys.Bayeux.Client
             WebSocketReceiveResult result = null;
             do
             {
-                result = await webSocket.ReceiveAsync(buffer, cancellationToken);
+                result = await webSocket.ReceiveAsync(buffer, cancellationToken).ConfigureAwait(false);
                 stream.Write(buffer.Array, buffer.Offset, result.Count);
             }
             while (!result.EndOfMessage);
@@ -200,12 +200,12 @@ namespace Genesys.Bayeux.Client
             
             var messageStr = JsonConvert.SerializeObject(requestsJArray);
             log.Debug(() => $"Posting: {messageStr}");
-            await SendAsync(messageStr, cancellationToken);
+            await SendAsync(messageStr, cancellationToken).ConfigureAwait(false);
 
             var timeoutTask = Task.Delay(responseTimeout, cancellationToken);
             Task completedTask = await Task.WhenAny(
                 Task.WhenAll(responseTasks.Select(t => t.Task)),
-                timeoutTask);
+                timeoutTask).ConfigureAwait(false);
 
             foreach (var id in messageIds)
                 pendingRequests.TryRemove(id, out var _);
@@ -217,7 +217,7 @@ namespace Genesys.Bayeux.Client
             }
             else
             {
-                return await responseTasks.First().Task;
+                return await responseTasks.First().Task.ConfigureAwait(false);
             }
         }
 
@@ -230,7 +230,7 @@ namespace Genesys.Bayeux.Client
                     bytes,
                     WebSocketMessageType.Text,
                     endOfMessage: true,
-                    cancellationToken: cancellationToken);
+                    cancellationToken: cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
I created constructors to for each valid method of instantiating HttpLongPollingTransportOptions.  I also added a default constructor to mark it as obsolete, which will allow anyone setting HttpPost or HttpClient directly to know that it will be switched.